### PR TITLE
Replace browser history instead of pushing to it

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -142,7 +142,7 @@ window.onload = function() {
   }
 
   function setQueryString() {
-    location.hash = qs.stringify({
+    const queryString = qs.stringify({
       seed: menu.seed,
       fov: menu.fov,
       pointStars: menu.pointStars,
@@ -152,6 +152,12 @@ window.onload = function() {
       resolution: menu.resolution,
       animationSpeed: menu.animationSpeed
     });
+
+    try {
+      history.replaceState(null, "", "#" + queryString);
+    } catch (e) {
+      location.hash = queryString;
+    }
   }
 
   var hideControls = false;

--- a/src/main.js
+++ b/src/main.js
@@ -142,7 +142,7 @@ window.onload = function() {
   }
 
   function setQueryString() {
-    const queryString = qs.stringify({
+    var queryString = qs.stringify({
       seed: menu.seed,
       fov: menu.fov,
       pointStars: menu.pointStars,


### PR DESCRIPTION
Previously the browser history would be severely spammed whenever the settings were rapidly changed (e.g. FOV change).
This commit changes it to use `history.replaceState` instead, which replaces the current entry in history instead of creating a new entry. A fallback has been added just in case `history.replaceState` fails, although it should be implemented all the way back to IE10.

![Comparison](https://user-images.githubusercontent.com/4542461/95311971-a285fb80-088e-11eb-942c-7cba7d84f2d1.png)
